### PR TITLE
Fix for "There is no way of knowing if a correct xr_session has been created"

### DIFF
--- a/StereoKit/StereoKit.cs
+++ b/StereoKit/StereoKit.cs
@@ -25,14 +25,18 @@ namespace StereoKit
         static extern float sk_timef();
         #endregion
 
-        public StereoKitApp(string name, Runtime runtime)
+        public StereoKitApp()
         {
-            sk_init(name, runtime);
         }
         ~StereoKitApp()
         {
             GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, false);
             sk_shutdown();
+        }
+
+        public bool Initialize(string name, Runtime runtime)
+        {
+            return sk_init(name, runtime);
         }
 
         public bool Step(Action onStep)

--- a/StereoKitTest/Program.cs
+++ b/StereoKitTest/Program.cs
@@ -5,9 +5,14 @@ class Program
 {
     static void Main(string[] args) 
     {
-        StereoKitApp kit = new StereoKitApp("StereoKit C#", Runtime.MixedReality);
+        StereoKitApp kit = new StereoKitApp();
+        if (!kit.Initialize("StereoKit C#", Runtime.MixedReality))
+        {
+            Console.WriteLine("Can't create xr_session!");
+            Environment.Exit(1);
+        }
 
-        Model     gltf   = new Model("Assets/DamagedHelmet.gltf");
+        Model gltf   = new Model("Assets/DamagedHelmet.gltf");
         Transform gltfTr = new Transform(Vec3.Zero, Vec3.One*0.5f);
         
         Input.Subscribe(InputSource.Hand, InputState.Any, (src, st, p) => {


### PR DESCRIPTION
Fix for Issue #3 (There is no way of knowing if a correct xr_session has been created)

- Added initialization in line with the C behavior
- Changed C# example accordingly

Potential further improvements: Currently chaining the Initialization() calls fails (for example calling it once with Runtime.MixedReality and if that fails with Runtime.Flatscreen) because of some internal configuration that already happened. Ideally this should work.