### PR TITLE
Fix for Issue 16 allowing init() to be safely run multiple times

### DIFF
--- a/StereoKitC/d3d.cpp
+++ b/StereoKitC/d3d.cpp
@@ -12,14 +12,14 @@ ID3D11RasterizerState    *d3d_rasterstate   = nullptr;
 int                       d3d_screen_width  = 640;
 int                       d3d_screen_height = 480;
 
-void d3d_init() {
+bool d3d_init() {
 	UINT creation_flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 #ifdef _DEBUG
 	creation_flags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 	D3D_FEATURE_LEVEL featureLevels[] = { D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0 };
 	if (FAILED(D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, 0, creation_flags, featureLevels, _countof(featureLevels), D3D11_SDK_VERSION, &d3d_device, nullptr, &d3d_context)))
-		MessageBox(0, "\tFailed to init d3d!\n", "Error", 0);
+		return false;
 
 	D3D11_DEPTH_STENCIL_DESC desc_depthstate = {};
 	desc_depthstate.DepthEnable    = true;
@@ -49,13 +49,14 @@ void d3d_init() {
 		d3d_context->PSSetSamplers(i, 1, &d3d_samplerstate);
 	}
 	
-
 	D3D11_RASTERIZER_DESC desc_rasterizer = {};
 	desc_rasterizer.FillMode = D3D11_FILL_SOLID;
 	desc_rasterizer.CullMode = D3D11_CULL_BACK;
 	desc_rasterizer.FrontCounterClockwise = true;
 	d3d_device->CreateRasterizerState(&desc_rasterizer, &d3d_rasterstate);
 	d3d_context->RSSetState(d3d_rasterstate);
+
+	return true;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/d3d.h
+++ b/StereoKitC/d3d.h
@@ -8,7 +8,7 @@ extern ID3D11DeviceContext    *d3d_context;
 extern int                     d3d_screen_width;
 extern int                     d3d_screen_height;
 
-void d3d_init         ();
+bool d3d_init         ();
 void d3d_shutdown     ();
 void d3d_render_begin ();
 void d3d_render_end   ();

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -15,6 +15,8 @@ sk_runtime_ sk_runtime = sk_runtime_flatscreen;
 bool sk_focused = true;
 bool sk_run     = true;
 
+bool sk_d3d_initialized = false;
+
 float  sk_timevf = 0;
 double sk_timev  = 0;
 double sk_time_start    = 0;
@@ -25,14 +27,28 @@ long long sk_timev_raw = 0;
 tex2d_t    sk_default_tex;
 shader_t   sk_default_shader;
 material_t sk_default_material;
-void sk_create_defaults();
+bool sk_create_defaults();
 void sk_destroy_defaults();
 
 bool sk_init(const char *app_name, sk_runtime_ runtime) {
 	sk_runtime = runtime;
 
-	d3d_init();
-	sk_create_defaults();
+	// Test to avoid initializing the d3d context twice
+	if (!sk_d3d_initialized) {
+		if (d3d_init()) {
+			sk_d3d_initialized = true;
+		}
+		else {
+			MessageBox(0, "\tFailed to init d3d!\n", "Error", 0);
+			return false;
+		}
+	}
+
+	if (!sk_create_defaults())
+	{
+		MessageBox(0, "\tFailed to create defaults!\n", "Error", 0);
+		return false;
+	}
 	
 	bool result = true;
 	switch (sk_runtime) {
@@ -102,8 +118,12 @@ double sk_time         (){ return sk_timev; };
 float  sk_time_elapsedf(){ return sk_timev_elapsedf; };
 double sk_time_elapsed (){ return sk_timev_elapsed; };
 
-void sk_create_defaults() {
+bool sk_create_defaults() {
 	sk_default_tex = tex2d_create("default/tex2d");
+	if (sk_default_tex == nullptr) {
+		return false;
+	}
+
 	uint8_t tex_colors[4 * 4];
 	memset(tex_colors, 255, sizeof(uint8_t) * 4 * 4);
 	tex2d_set_colors(sk_default_tex, 2, 2, tex_colors);
@@ -159,10 +179,19 @@ float4 ps(psIn input) : SV_TARGET {
 
 	return float4(col, _color.a); 
 })_");
+	if (sk_default_shader == nullptr) {
+		return false;
+	}
 
 	sk_default_material = material_create("default/material", sk_default_shader);
+	if (sk_default_material == nullptr) {
+		return false;
+	}
+
 	material_set_texture(sk_default_material, "diffuse", sk_default_tex);
 	material_set_color32(sk_default_material, "color", { 255,255,255,255 });
+
+	return true;
 }
 
 void sk_destroy_defaults() {

--- a/StereoKitCTest/main.cpp
+++ b/StereoKitCTest/main.cpp
@@ -3,9 +3,19 @@
 transform_t gltf_tr;
 model_t     gltf;
 
+bool runningInMRMode = false;
+
 int main() {
-	sk_init("StereoKit C", sk_runtime_mixedreality);
-	
+	if (sk_init("StereoKit C", sk_runtime_mixedreality)) {
+		runningInMRMode = true;
+	}
+	else if (sk_init("StereoKit C", sk_runtime_flatscreen)) {
+		runningInMRMode = false;
+	}
+	else {
+		return 1;
+	}
+
 	//gltf = model_create_file("Assets/DamagedHelmet.gltf");
 	gltf = model_create_mesh("app/model_cube", 
 		mesh_gen_cube("app/mesh_cube", { .1f,.1f,.1f }, 0), 

--- a/StereoKitTest/Program.cs
+++ b/StereoKitTest/Program.cs
@@ -3,16 +3,28 @@ using StereoKit;
 
 class Program 
 {
+    static bool runningInMRMode = true;
+
     static void Main(string[] args) 
     {
         StereoKitApp kit = new StereoKitApp();
-        if (!kit.Initialize("StereoKit C#", Runtime.MixedReality))
+        if (kit.Initialize("StereoKit C#", Runtime.MixedReality))
         {
-            Console.WriteLine("Can't create xr_session!");
+            Console.WriteLine("Created xr_session, runnning in MixedReality mode!");
+            runningInMRMode = true;
+        }
+        else if (kit.Initialize("StereoKit C#", Runtime.Flatscreen))
+        {
+            Console.WriteLine("Can't create xr_session, running in Flatscreen mode instead!");
+            runningInMRMode = false;
+        }
+        else
+        {
+            Console.WriteLine("Can't create xr_session nor a desktop window instance!");
             Environment.Exit(1);
         }
 
-        Model gltf   = new Model("Assets/DamagedHelmet.gltf");
+        Model gltf       = new Model("Assets/DamagedHelmet.gltf");
         Transform gltfTr = new Transform(Vec3.Zero, Vec3.One*0.5f);
         
         Input.Subscribe(InputSource.Hand, InputState.Any, (src, st, p) => {


### PR DESCRIPTION
This addresses #16 (Chaining initialization calls Fail).

This will allow init() to be run multiple times in case the first one fails, for example if creating a xr_session failed, but the developer wants to open a flatscreen session instead as fallback.

Details:
- Added check if d3d_init() has been called already
- Added error handling for d3d_init()
- Added error handling for sk_create_defaults()
- Updated the StereoKitCTest and StereoKitTest examples

Tested:
- Connecting MR headset, open app: Runs example in MR mode
- Disconnect MR headset, open app: Runs example in flatscreen mode
- Prevent app from opening a window, open app: App exists out as expected