### PR TITLE
Fix the WINAPI_FAMILY_PARTITION and asset path

### DIFF
--- a/Examples/StereoKitCTest/StereoKitCTest.vcxproj
+++ b/Examples/StereoKitCTest/StereoKitCTest.vcxproj
@@ -14,7 +14,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{B9F338BD-A226-43BF-B6B5-A797F51C7B0D}</ProjectGuid>
     <RootNamespace>StereoKitCTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <ProjectName>StereoKitCTest</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -6,6 +6,7 @@ using namespace sk;
 #include "demo_ui.h"
 #include "demo_sprites.h"
 
+#include <winapifamily.h>
 #include <stdio.h>
 
 solid_t     floor_solid;
@@ -33,18 +34,18 @@ void common_init();
 void common_update();
 void common_shutdown();
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
-const char* assets_folder = "Assets";
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+const char* assets_folder = "../../Examples/Assets";
 #else
-const char* assets_folder = "../../../Examples/Assets";
+const char* assets_folder = "Assets";
 #endif
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+int main() {
+#else
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
-#else
-int main() {
 #endif
 	settings_t settings = {};
 	sprintf_s(settings.assets_folder, assets_folder);

--- a/StereoKitC/StereoKitC.vcxproj
+++ b/StereoKitC/StereoKitC.vcxproj
@@ -14,7 +14,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{95B47C8E-3A66-483C-ABEE-950E6C2F621A}</ProjectGuid>
     <RootNamespace>StereoKitC</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <ProjectName>StereoKitC</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Fix some minor issues:
1. winapifamily.h was not included, so WINAPI_FAMILY_PARTITION is not defined.
2. The start directory of StereoKitCTest project is in Examples/StereoKitCTest. It can't locate ../../../Examples/Assets.
3. Native projects' <WindowsTargetPlatformVersion> is not consistent with other projects.