### PR TITLE
Correctly initialise structures before locating hands with OpenXR

### DIFF
--- a/StereoKitC/systems/hand/hand_oxr_articulated.cpp
+++ b/StereoKitC/systems/hand/hand_oxr_articulated.cpp
@@ -57,7 +57,12 @@ void hand_oxra_update_joints() {
 		XrHandJointsLocateInfoEXT locate_info = { XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
 		locate_info.time      = xr_time;
 		locate_info.baseSpace = xr_app_space;
+
+		XrHandJointLocationEXT joint_locations[XR_HAND_JOINT_COUNT_EXT];
 		XrHandJointLocationsEXT locations = { XR_TYPE_HAND_JOINT_LOCATIONS_EXT };
+		locations.isActive = XR_FALSE;
+		locations.jointCount = XR_HAND_JOINT_COUNT_EXT;
+		locations.jointLocations = joint_locations;
 		xr_extensions.xrLocateHandJointsEXT(oxra_hand_tracker[h], &locate_info, &locations);
 
 		// Update the tracking state of the hand


### PR DESCRIPTION
Correctly initialise the `XrHandJointLocationsEXT` structure members `jointCount` and `jointLocations` before calling `xrLocateHandJointsEXT`. Without this the call will fail with an incorrectly zero `jointCount`, or segfault accessing the null pointer for `jointLocations`.

This fixes support for XR_EXT_hand_tracking in #84 