### PR TITLE
[hotfix] Switched back to replace method as replaceAll is not widely supported.

### DIFF
--- a/docs/src/docs.js
+++ b/docs/src/docs.js
@@ -84,14 +84,14 @@ function renderFolder(folder, parent, hierarchy) {
 
     // Link to the actual document
     var link = document.createElement("a");
-    link.href      = "{{site.url}}/"+hierarchy+"/"+folder.name.replaceAll(" ", "-")+".html";
+    link.href      = "{{site.url}}/"+hierarchy+"/"+folder.name.replace(/ /g, '-')+".html";
     link.innerText = folder.name;
     folderItem.appendChild(link);
 
     // Render sub-folders
     if (hasChildren) {
         // Update the URL hierarchy
-        hierarchy += "/"+folder.name.replaceAll(" ", "-");
+        hierarchy += "/"+folder.name.replace(/ /g, '-');
 
         // We need a sub-menu for the folding to work
         var subList = document.createElement("ul");


### PR DESCRIPTION
This PR reverts a recent change (030bc671124e014dba0e1edf5c080a6f92f302cd) wherein the method `replace` was swapped for `replaceAll`. Unfortunately, `replaceAll` is only supported in the latest version of Firefox and Safari. Both Chrome and Edge are currently missing this feature.

https://caniuse.com/#search=replaceAll

I've also added a global flag to the regular expression, replicating the functionality of the `replaceAll` method.