### PR TITLE
[feat] Renderer.Projection and Matrix Multiplication

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -262,6 +262,7 @@ namespace StereoKit
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   render_set_clip      (float near_plane, float far_plane);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   render_set_fov       (float field_of_view_degrees);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Matrix render_get_projection();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Matrix render_get_cam_root  ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   render_set_cam_root  (Matrix cam_root);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   render_set_skytex    (IntPtr sky_texture);

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -54,6 +54,8 @@ namespace StereoKit
 			set => NativeAPI.render_set_cam_root(value);
 		}
 
+		public static Matrix Projection => NativeAPI.render_get_projection();
+
 		/// <summary>Adds a mesh to the render queue for this frame! If the Hierarchy has a transform on it,
 		/// that transform is combined with the Matrix provided here.</summary>
 		/// <param name="mesh">A valid Mesh you wish to draw.</param>

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -592,6 +592,7 @@ SK_API void line_add_listv(const line_point_t *points, int32_t count);
 
 SK_API void     render_set_clip      (float near_plane sk_default(0.01f), float far_plane sk_default(50));
 SK_API void     render_set_fov       (float field_of_view_degrees sk_default(90.0f));
+SK_API matrix   render_get_projection();
 SK_API matrix   render_get_cam_root  ();
 SK_API void     render_set_cam_root  (const sk_ref(matrix) cam_root);
 SK_API void     render_set_skytex    (tex_t sky_texture);


### PR DESCRIPTION
This PR exposes the projection matrix from the renderer and adds the ability to multiply a `Matrix` by a `Vec4`.

These changes are to support adding features similar to the [Camera.WorldToScreenPoint](https://docs.unity3d.com/ScriptReference/Camera.WorldToScreenPoint.html) and [Camera.WorldToViewportPoint](https://docs.unity3d.com/ScriptReference/Camera.WorldToViewportPoint.html) in Unity.