### PR TITLE
Allow disabling the physics system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SK_LINUX_EGL                    OFF CACHE BOOL "Force using EGL graphics bac
 set(SK_MULTITHREAD_BUILD_BY_DEFAULT ON  CACHE BOOL "MSVC only, on by default. This forces projects here to build with multi-threading (/MP)")
 set(SK_BUILD_TESTS                  ON  CACHE BOOL "Build the StereoKitCTest project in addition to the StereoKitC library.")
 set(SK_BUILD_SHARED_LIBS            ON  CACHE BOOL "Should StereoKit build as a shared, or static library?")
+set(SK_SYSTEMS_PHYSICS              ON  CACHE BOOL "Build the physics system")
 
 ###########################################
 ## Dependencies                          ##
@@ -54,18 +55,20 @@ if (UNIX)
   set(CPM_USE_LOCAL_PACKAGES ON) # Tell CPM to prefer locally installed packages
 endif()
 
-#### ReactPhysics3D - https://www.reactphysics3d.com/ ####
-CPMAddPackage(
-  NAME reactphysics3d
-  GITHUB_REPOSITORY DanielChappuis/reactphysics3d
-  GIT_TAG bdc3153f552f6665ea9d2d13afd20ea871119e17 # v0.8.0
-)
-# Something in reactphysics3d seems to require -fPIC
-set_property(TARGET reactphysics3d PROPERTY POSITION_INDEPENDENT_CODE ON)
-# Disable warnings for reactphysics3d, it's a little horrifying
-target_compile_options(reactphysics3d PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W0>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w> )
+if(SK_SYSTEMS_PHYSICS)
+	#### ReactPhysics3D - https://www.reactphysics3d.com/ ####
+	CPMAddPackage(
+	NAME reactphysics3d
+	GITHUB_REPOSITORY DanielChappuis/reactphysics3d
+	GIT_TAG bdc3153f552f6665ea9d2d13afd20ea871119e17 # v0.8.0
+	)
+	# Something in reactphysics3d seems to require -fPIC
+	set_property(TARGET reactphysics3d PROPERTY POSITION_INDEPENDENT_CODE ON)
+	# Disable warnings for reactphysics3d, it's a little horrifying
+	target_compile_options(reactphysics3d PRIVATE
+	$<$<CXX_COMPILER_ID:MSVC>:/W0>
+	$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w> )
+endif()
 
 #### OpenXR - https://www.khronos.org/openxr/ ####
 CPMAddPackage(
@@ -223,8 +226,6 @@ set(SK_SRC_SYSTEMS
   StereoKitC/systems/input_keyboard.cpp
   StereoKitC/systems/line_drawer.h
   StereoKitC/systems/line_drawer.cpp
-  StereoKitC/systems/physics.h
-  StereoKitC/systems/physics.cpp
   StereoKitC/systems/render.h
   StereoKitC/systems/render.cpp
   StereoKitC/systems/render_sort.h
@@ -237,6 +238,13 @@ set(SK_SRC_SYSTEMS
   StereoKitC/systems/text.cpp  
   StereoKitC/systems/world.h
   StereoKitC/systems/world.cpp )
+
+if(SK_SYSTEMS_PHYSICS)
+  list(APPEND SK_SRC_SYSTEMS 
+    StereoKitC/systems/physics.h
+    StereoKitC/systems/physics.cpp )
+    add_definitions("-DSK_SYSTEMS_PHYSICS")
+endif()
 
 set(SK_SRC_HANDS
   StereoKitC/systems/hand/hand_mouse.h
@@ -274,7 +282,7 @@ set(SK_SRC_PLATFORM
   StereoKitC/systems/platform/win32.h
   StereoKitC/systems/platform/win32.cpp )
 
-set(SK_SRC_TOOLS
+set(SK_SRC_TOOLS 
   StereoKitC/tools/file_picker.h
   StereoKitC/tools/file_picker.cpp )
 
@@ -321,9 +329,14 @@ target_include_directories(StereoKitC
     ${LINUX_INCLUDES}
 )
 
-target_link_libraries( StereoKitC
-  PRIVATE
+if(SK_SYSTEMS_PHYSICS)
+  target_link_libraries( StereoKitC
+    PRIVATE
     reactphysics3d
+  )
+endif()
+
+target_link_libraries( StereoKitC
   PUBLIC
     openxr_loader
     ${LINUX_LIBS}
@@ -336,10 +349,8 @@ target_link_libraries( StereoKitC
 ###########################################
 
 if (SK_BUILD_TESTS)
-  add_executable( StereoKitCTest
+  set(SK_C_TEST_SRC 
     Examples/StereoKitCTest/main.cpp
-    Examples/StereoKitCTest/demo_basics.h
-    Examples/StereoKitCTest/demo_basics.cpp
     Examples/StereoKitCTest/demo_picker.h
     Examples/StereoKitCTest/demo_picker.cpp
     Examples/StereoKitCTest/demo_mic.h
@@ -361,6 +372,15 @@ if (SK_BUILD_TESTS)
     Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl.h
     Examples/StereoKitCTest/Shaders/skt_light_only.hlsl.h
   )
+  if(SK_SYSTEMS_PHYSICS)
+    list(APPEND SK_C_TEST_SRC
+      Examples/StereoKitCTest/demo_basics.h
+      Examples/StereoKitCTest/demo_basics.cpp
+    )
+  endif()
+  add_executable( StereoKitCTest
+    ${SK_C_TEST_SRC}
+  )
 
   target_link_libraries( StereoKitCTest
     StereoKitC
@@ -379,7 +399,9 @@ endif()
 # default, this is mostly for when using Visual Studio as
 # the IDE. CLI users can pass in command line arguments.
 if (MSVC AND SK_MULTITHREAD_BUILD_BY_DEFAULT)
-  target_compile_options(reactphysics3d PRIVATE "/MP")
+  if(SK_SYSTEMS_PHYSICS)
+    target_compile_options(reactphysics3d PRIVATE "/MP")
+  endif()
   target_compile_options(openxr_loader PRIVATE "/MP")
   target_compile_options(StereoKitC PRIVATE "/MP")
 endif()

--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -4,7 +4,9 @@
 using namespace sk;
 
 #include "scene.h"
+#ifdef SK_SYSTEMS_PHYSICS
 #include "demo_basics.h"
+#endif
 #include "demo_ui.h"
 #include "demo_mic.h"
 #include "demo_sprites.h"
@@ -18,18 +20,22 @@ using namespace sk;
 #include <string>
 #include <list>
 
+#ifdef SK_SYSTEMS_PHYSICS
 solid_t     floor_solid;
+#endif
 matrix      floor_tr;
 material_t  floor_mat;
 model_t     floor_model;
 
 scene_t demos[] = {
 	{
+#ifdef SK_SYSTEMS_PHYSICS
 		"Basics",
 		demo_basics_init,
 		demo_basics_update,
 		demo_basics_shutdown,
 	}, {
+#endif
 		"UI",
 		demo_ui_init,
 		demo_ui_update,
@@ -114,13 +120,17 @@ int __stdcall wWinMain(void*, void*, wchar_t*, int) {
 	sk_settings_t settings = {};
 	settings.app_name           = "StereoKit C";
 	settings.assets_folder      = "Assets";
-	settings.display_preference = display_mode_mixedreality;
+	settings.display_preference = display_mode_flatscreen;
 	if (!sk_init(settings))
 		return 1;
 
 	common_init();
 
+#ifndef SK_SYSTEMS_PHYSICS
+	scene_set_active(demos[5]);
+#else
 	scene_set_active(demos[6]);
+#endif
 
 	while (sk_step( []() {
 		scene_update();
@@ -156,8 +166,10 @@ void common_init() {
 	vec3 pos   = vec3{ 0,-1.5f,0 };
 	vec3 scale = vec3{ 5,1,5 };
 	floor_tr    = matrix_trs(pos, quat_identity, scale);
+#ifdef SK_SYSTEMS_PHYSICS
 	floor_solid = solid_create(pos, quat_identity, solid_type_immovable);
 	solid_add_box (floor_solid, scale);
+#endif
 
 	demo_select_pose.position = vec3{0, 0, -0.4f};
 	demo_select_pose.orientation = quat_lookat(vec3_forward, vec3_zero);
@@ -185,7 +197,9 @@ void common_update() {
 }
 
 void common_shutdown() {
+#ifdef SK_SYSTEMS_PHYSICS
 	solid_release   (floor_solid);
+#endif
 	material_release(floor_mat);
 	model_release   (floor_model);
 }

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -7,7 +7,9 @@
 
 #include "systems/render.h"
 #include "systems/input.h"
-#include "systems/physics.h"
+#ifdef SK_SYSTEMS_PHYSICS
+	#include "systems/physics.h"
+#endif
 #include "systems/system.h"
 #include "systems/text.h"
 #include "systems/audio.h"
@@ -143,21 +145,28 @@ bool32_t sk_init(sk_settings_t settings) {
 	sys_ui.func_shutdown           = ui_shutdown;
 	systems_add(&sys_ui);
 
-	system_t sys_physics = { "Physics" };
-	const char *physics_deps       [] = {"Defaults"};
-	const char *physics_update_deps[] = {"Input", "FrameBegin"};
-	sys_physics.init_dependencies       = physics_deps;
-	sys_physics.init_dependency_count   = _countof(physics_deps);
-	sys_physics.update_dependencies     = physics_update_deps;
-	sys_physics.update_dependency_count = _countof(physics_update_deps);
-	sys_physics.func_initialize         = physics_init;
-	sys_physics.func_update             = physics_update;
-	sys_physics.func_shutdown           = physics_shutdown;
-	systems_add(&sys_physics);
+	#ifdef SK_SYSTEMS_PHYSICS
+		system_t sys_physics = { "Physics" };
+		const char *physics_deps       [] = {"Defaults"};
+		const char *physics_update_deps[] = {"Input", "FrameBegin"};
+		sys_physics.init_dependencies       = physics_deps;
+		sys_physics.init_dependency_count   = _countof(physics_deps);
+		sys_physics.update_dependencies     = physics_update_deps;
+		sys_physics.update_dependency_count = _countof(physics_update_deps);
+		sys_physics.func_initialize         = physics_init;
+		sys_physics.func_update             = physics_update;
+		sys_physics.func_shutdown           = physics_shutdown;
+		systems_add(&sys_physics);
+	#endif
 
 	system_t sys_renderer = { "Renderer" };
 	const char *renderer_deps       [] = {"Platform", "Defaults"};
-	const char *renderer_update_deps[] = {"Physics", "FrameBegin"};
+	const char *renderer_update_deps[] = {
+#ifdef SK_SYSTEMS_PHYSICS
+		"Physics",
+#endif
+		"FrameBegin"
+	};
 	sys_renderer.init_dependencies       = renderer_deps;
 	sys_renderer.init_dependency_count   = _countof(renderer_deps);
 	sys_renderer.update_dependencies     = renderer_update_deps;
@@ -239,7 +248,18 @@ bool32_t sk_init(sk_settings_t settings) {
 	systems_add(&sys_world);
 
 	system_t sys_app = { "App" };
-	const char *app_update_deps[] = {"Input", "Defaults", "FrameBegin", "Platform", "Physics", "Renderer", "UI", "World"};
+	const char *app_update_deps[] = {
+		"Input",
+		"Defaults",
+		"FrameBegin",
+		"Platform",
+		#ifdef SK_SYSTEMS_PHYSICS
+		"Physics",
+		#endif
+		"Renderer",
+		"UI",
+		"World"
+	};
 	sys_app.update_dependencies     = app_update_deps;
 	sys_app.update_dependency_count = _countof(app_update_deps);
 	sys_app.func_update             = sk_app_update;
@@ -353,7 +373,9 @@ void time_set_time(double total_seconds, double frame_elapsed_seconds) {
 	sk_timev_elapsedf    = (float)sk_timev_elapsed;
 	sk_timevf_us         = (float)sk_timev_us;
 	sk_timevf            = (float)sk_timev;
+#ifdef SK_SYSTEMS_PHYSICS
 	physics_sim_time     = sk_timev;
+#endif
 }
 
 } // namespace sk

--- a/StereoKitC/systems/hand/input_hand.cpp
+++ b/StereoKitC/systems/hand/input_hand.cpp
@@ -27,7 +27,9 @@ namespace sk {
 struct hand_state_t {
 	hand_t      info;
 	pose_t      pose_blend[5][5];
+#ifdef SK_SYSTEMS_PHYSICS
 	solid_t     solids[SK_FINGER_SOLIDS];
+#endif
 	material_t  material;
 	hand_mesh_t mesh;
 	bool        visible;
@@ -200,9 +202,11 @@ void input_hand_init() {
 		hand_state[i].info.handedness = (handed_)i;
 		input_hand_update_mesh((handed_)i);
 
+#ifdef SK_SYSTEMS_PHYSICS
 		hand_state[i].solids[0] = solid_create(vec3_zero, quat_identity, solid_type_unaffected);
 		solid_add_box    (hand_state[i].solids[0], vec3{ 0.03f, .1f, .2f });
 		solid_set_enabled(hand_state[i].solids[0], false);
+#endif
 
 		// Set up initial default hand pose, so we don't get any accidental pinch/grips on start
 		memcpy(hand_state[i].pose_blend, input_pose_neutral, sizeof(pose_t) * SK_FINGERS * SK_FINGERJOINTS);
@@ -241,9 +245,11 @@ void input_hand_shutdown() {
 	}
 
 	for (size_t i = 0; i < handed_max; i++) {
+#ifdef SK_SYSTEMS_PHYSICS
 		for (size_t f = 0; f < SK_FINGER_SOLIDS; f++) {
 			solid_release(hand_state[i].solids[f]);
 		}
+#endif
 		material_release(hand_state[i].material);
 		mesh_release    (hand_state[i].mesh.mesh);
 		free(hand_state[i].mesh.inds);
@@ -287,12 +293,14 @@ void input_hand_update() {
 		}
 
 		// Update hand physics
+#ifdef SK_SYSTEMS_PHYSICS
 		if (hand_state[i].solid) {
 			solid_set_enabled(hand_state[i].solids[0], tracked);
 			if (tracked) {
 				solid_move(hand_state[i].solids[0], hand_state[i].info.palm.position, hand_state[i].info.palm.orientation);
 			}
 		}
+#endif
 	}
 
 	for (size_t i = 0; i < _countof(hand_sources); i++) {
@@ -613,6 +621,7 @@ void input_hand_visible(handed_ hand, bool32_t visible) {
 ///////////////////////////////////////////
 
 void input_hand_solid(handed_ hand, bool32_t solid) {
+#ifdef SK_SYSTEMS_PHYSICS
 	if (hand == handed_max) {
 		input_hand_solid(handed_left,  solid);
 		input_hand_solid(handed_right, solid);
@@ -623,6 +632,7 @@ void input_hand_solid(handed_ hand, bool32_t solid) {
 	for (size_t i = 0; i < SK_FINGER_SOLIDS; i++) {
 		solid_set_enabled(hand_state[hand].solids[i], solid);
 	}
+#endif
 }
 
 ///////////////////////////////////////////

--- a/xmake.lua
+++ b/xmake.lua
@@ -60,6 +60,7 @@ target("StereoKitC")
     set_version("0.3.3-preview.3")
     set_kind("shared")
     set_symbols("debug")
+	add_defines("SK_SYSTEMS_PHYSICS")
     if is_plat("windows") then
         set_languages("cxx17")
         add_cxflags(is_mode("debug") and "/MDd" or "/MD")


### PR DESCRIPTION
For most people, this isn't necessary... but given it takes 3/4 of the time compiling react physics I figured it was worth having the option. PR #176 should be applied before this one if I understand correctly.