### PR TITLE
Vec shorthands in the struct itself

### DIFF
--- a/StereoKit/Math/Vec2.cs
+++ b/StereoKit/Math/Vec2.cs
@@ -23,6 +23,10 @@ namespace StereoKit
 		/// <param name="y">Y component of the vector.</param>
 		public Vec2(float x, float y) => v = new Vector2(x, y);
 
+		/// <summary>A short hand constructor, just sets all values as the same!</summary>
+		/// <param name="xy">X and Y component of the vector.</param>
+		public Vec2(float xy) => v = new Vector2(xy, xy);
+
 		public static implicit operator Vec2(Vector2 v) => new Vec2(v.X, v.Y);
 		public static implicit operator Vector2(Vec2 v) => v.v;
 

--- a/StereoKit/Math/Vec3.cs
+++ b/StereoKit/Math/Vec3.cs
@@ -29,6 +29,12 @@ namespace StereoKit
 		/// <param name="z">The z axis.</param>
 		public Vec3(float x, float y, float z) => v = new Vector3(x, y, z);
 
+		/// <summary>Creates a vector with all values the same! StereoKit uses
+		/// a right-handed metric coordinate system, where +x is to the 
+		/// right, +y is upwards, and -z is forward.</summary>
+		/// <param name="xyz">The x,y,and z axis.</param>
+		public Vec3(float xyz) => v = new Vector3(xyz, xyz, xyz);
+
 		public static implicit operator Vec3(Vector3 v) => new Vec3(v.X, v.Y, v.Z);
 		public static implicit operator Vector3(Vec3 v) => v.v;
 

--- a/StereoKit/Math/Vec4.cs
+++ b/StereoKit/Math/Vec4.cs
@@ -59,7 +59,13 @@ namespace StereoKit
 		public Vec4(float x, float y, float z, float w) 
 			=> v = new Vector4(x, y, z, w);
 
-		/// <summary>A basic constructor, just copies the values in!</summary>
+
+		/// <summary>A basic constructor, just copies the value in as x,y,z and,w component!</summary>
+		/// <param name="xyzw">X,Y,Z,and W component of the vector.</param>
+		public Vec4(float xyzw)
+			=> v = new Vector4(xyzw, xyzw, xyzw, xyzw);
+
+		/// <summary>A short hand constructor, just copies the values in!</summary>
 		/// <param name="xyz">X, Y and Z components of the vector.</param>
 		/// <param name="w">W component of the vector.</param>
 		public Vec4(Vec3 xyz, float w)


### PR DESCRIPTION
It is not obvious to people that they should use static class V for the shorthand so this makes it easier for people that are used to system numerics constructors.