### PR TITLE
Fix docs folder items shifted by expander arrow

### DIFF
--- a/docs/src/docs.js
+++ b/docs/src/docs.js
@@ -67,20 +67,32 @@ function renderFolder(folder, parent, hierarchy) {
     folder.element = folderItem;
     parent.appendChild(folderItem);
 
+    var expanderContainer = document.createElement("span");
+    expanderContainer.className = "expander-container";
+    expanderContainer.setAttribute("aria-hidden", true);
+
     // If there are child pages, make it expandable
     if (hasChildren) {
-        // The expand tree arrow
-        var expander = document.createElement("input");
-        expander.className = "tree-branch-check";
-        expander.type      = "checkbox";
-        expander.setAttribute('aria-label', "Expand " + folder.name);
-        expander.onclick   = function() { treeDict.setItem(folder.name, !this.checked); };
-        folder.check = expander;
-        folderItem.appendChild(expander);
+        var expanderId = "expander-" + folder.name.replace(/ /g, '-');
 
-        // A span for some of the tree trickery
-        folderItem.appendChild(document.createElement("span"));
+        // Label which proxies clicks to the expander checkbox input
+        var expander = document.createElement("label");
+        expander.htmlFor = expanderId;
+        expanderContainer.appendChild(expander);
+
+        // The checkbox input used to store expand state. Also used in CSS to hide the child page lists and for keyboard focus.
+        var checkbox = document.createElement("input");
+        checkbox.id = expanderId;
+        checkbox.className = "tree-branch-check";
+        checkbox.type      = "checkbox";
+        checkbox.setAttribute('aria-label', "Expand " + folder.name);
+        checkbox.onclick   = function() { treeDict.setItem(folder.name, !this.checked); };
+        folder.check = checkbox;
+        folderItem.appendChild(checkbox);
     }
+
+    // Append the expander container after the checkbox input
+    folderItem.appendChild(expanderContainer);
 
     // Link to the actual document
     var link = document.createElement("a");

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -188,29 +188,36 @@ main img {
 
 /* Tree view styling*/
 .tree-view ul {
-    margin-left: 0; 
     padding-left: 0;
 }
+.tree-view>ul ul {
+    margin-left: 1em;
+}
 .tree-view li {
-    margin-left: 1em; 
     padding-left: 0;
     list-style: none;
 }
 .tree-view input {
-    opacity:0;
-    margin-left: -1em; 
+    /* Keep expanders keyboard accessible, but not affect the page layout. */
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.tree-view .expander-container {
+    display: inline-block;
+    width: 1em;
+}
+.tree-view .expander-container>label {
     cursor: pointer;
 }
-.tree-view input ~ span:before {
-    content:"\25BD";
-    left:-1em;
-    margin-right:-1em;
-    position: relative;
-    z-index: -2;
-    cursor: pointer;
+.tree-view .expander-container>label:before {
+    content: "\25BD";
 }
-.tree-view input:checked ~ span:before {
-    content:"\25B7";
+.tree-view input:checked ~ .expander-container>label:before {
+    content: "\25B7";
+}
+.tree-view input:focus ~ .expander-container>label:before {
+    color: #3794FF;
 }
 .tree-view input:checked ~ ul {
     display:none;


### PR DESCRIPTION
The expander arrows were shifting the folder names and annoying me, so here's a fix. Before and after:

![comparison](https://user-images.githubusercontent.com/4833621/148600226-4a447d84-f2b6-4de5-b592-9d3a5e451f54.gif)

Wasn't sure if this should target master or develop, so I chose develop. I can change it if you want me to.