### PR TITLE
Call assets_releaseref_threadsafe only on non zero instance pointer

### DIFF
--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -58,7 +58,7 @@ namespace StereoKit
 		}
 		~Mesh()
 		{
-			if (_inst == IntPtr.Zero)
+			if (_inst != IntPtr.Zero)
 				NativeAPI.assets_releaseref_threadsafe(_inst);
 		}
 


### PR DESCRIPTION
Bugfix. It seems like Mesh release reference is only called on IntPtr.Zero, when it should be the other way around.